### PR TITLE
GitHub Packages changes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,6 +32,9 @@ jobs:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
 
+    permissions:
+      packages: write
+
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
@@ -54,7 +57,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ secrets.GHCR_AUTH_TOKEN }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build image
         uses: docker/build-push-action@v4.0.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM kasmweb/core-ubuntu-jammy:1.13.0
 USER root
 
+LABEL org.opencontainers.image.source="https://github.com/fprime-community/fprime-workspace-image"
+
 ENV HOME /home/kasm-default-profile
 ENV STARTUPDIR /dockerstartup
 ENV INST_SCRIPTS $STARTUPDIR/install


### PR DESCRIPTION
2 changes:

1. Added a label to the image. See https://docs.github.com/en/enterprise-server@3.8/packages/working-with-a-github-packages-registry/working-with-the-container-registry#labelling-container-images. This is to have it show up in the homepage of the repository, under Packages etc... (I believe)
2. Changed the way CI authenticates to `ghcr.io` registry, as suggested by https://docs.github.com/en/actions/security-guides/automatic-token-authentication